### PR TITLE
Fix bash template to add command completion for flags

### DIFF
--- a/packages/bash-generator/src/template.sh
+++ b/packages/bash-generator/src/template.sh
@@ -97,6 +97,11 @@ _{{commandName}}_completions()
       {{#if completion.oneOf}}
       COMPREPLY=($(compgen -W "{{ completion.oneOf }}" -- "$cur"))
       {{/if}}
+      {{#if completion.command}}
+      if {{#commandsExist completion.requiredCommands}}{{/commandsExist}}; then
+        COMPREPLY=($(compgen -W "$({{{completion.command}}})" -- "$cur"))
+      fi
+      {{/if}}
       return
     fi
     {{/each}}


### PR DESCRIPTION
We're using this for https://caddyserver.com to set up some bash/zsh completions.

See here: https://github.com/caddyserver/dist/tree/master/scripts/completions

We noticed the `command` type didn't work for `--flags`. Did some digging, it was just missing the bit in the template to handle it :+1: 

BTW it looks like for zsh, `command` was never implemented? Also we're having trouble with zsh positional args, the template doesn't seem to do anything with those.

/cc @Mohammed90